### PR TITLE
Expose details of next delivery and manual refresh of the data

### DIFF
--- a/custom_components/themodernmilkman/__init__.py
+++ b/custom_components/themodernmilkman/__init__.py
@@ -6,13 +6,15 @@ import asyncio
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
+from .const import CONF_COORDINATOR, DOMAIN, SERVICE_REFRESH_DATA
+from .coordinator import TMMCoordinator
 
-PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]
+PLATFORMS = [Platform.BUTTON, Platform.CALENDAR, Platform.SENSOR]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
@@ -21,6 +23,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass_data = dict(entry.data)
 
+    session = async_get_clientsession(hass)
+    coordinator = TMMCoordinator(hass, session, entry.data)
+    await coordinator.async_config_entry_first_refresh()
+    hass_data[CONF_COORDINATOR] = coordinator
+
     # Registers update listener to update config entry when options are updated.
     unsub_options_update_listener = entry.add_update_listener(options_update_listener)
 
@@ -28,6 +35,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(unsub_options_update_listener)
 
     hass.data[DOMAIN][entry.entry_id] = hass_data
+
+    async def _async_refresh_data(call: ServiceCall) -> None:
+        """Manually refresh data from The Modern Milkman API."""
+        for entry_id, entry_data in hass.data[DOMAIN].items():
+            if isinstance(entry_data, dict):
+                coord = entry_data.get(CONF_COORDINATOR)
+                if coord:
+                    await coord.async_request_refresh()
+
+    if not hass.services.has_service(DOMAIN, SERVICE_REFRESH_DATA):
+        hass.services.async_register(DOMAIN, SERVICE_REFRESH_DATA, _async_refresh_data)
+
     # Forward the setup to each platform.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -59,6 +78,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Remove config entry from domain.
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
+
+    # Remove service when no more entries are loaded.
+    if not hass.data[DOMAIN] and hass.services.has_service(DOMAIN, SERVICE_REFRESH_DATA):
+        hass.services.async_remove(DOMAIN, SERVICE_REFRESH_DATA)
 
     return unload_ok
 

--- a/custom_components/themodernmilkman/button.py
+++ b/custom_components/themodernmilkman/button.py
@@ -1,0 +1,47 @@
+"""The Modern Milkman button platform."""
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_COORDINATOR, DOMAIN
+from .coordinator import TMMCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up The Modern Milkman button from a config entry."""
+    coordinator: TMMCoordinator = hass.data[DOMAIN][entry.entry_id][CONF_COORDINATOR]
+    async_add_entities([TMMRefreshButton(coordinator, entry.title)])
+
+
+class TMMRefreshButton(CoordinatorEntity[TMMCoordinator], ButtonEntity):
+    """Button to manually refresh data from The Modern Milkman API."""
+
+    def __init__(self, coordinator: TMMCoordinator, name: str) -> None:
+        """Initialize the refresh button."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{DOMAIN}")},
+            manufacturer="The Modern Milkman",
+            model="Milkround",
+            name=name,
+            configuration_url="https://github.com/jampez77/TheModernMilkman/",
+        )
+        self._attr_unique_id = f"{DOMAIN}-{name}-refresh".lower()
+        self.entity_id = f"button.{DOMAIN}_refresh"
+        self.entity_description = ButtonEntityDescription(
+            key="themodernmilkman_refresh",
+            name="Refresh",
+            icon="mdi:refresh",
+        )
+
+    async def async_press(self) -> None:
+        """Refresh data from The Modern Milkman API."""
+        await self.coordinator.async_request_refresh()

--- a/custom_components/themodernmilkman/calendar.py
+++ b/custom_components/themodernmilkman/calendar.py
@@ -10,13 +10,13 @@ from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .coordinator import TMMCoordinator
 from .const import (
+    CONF_COORDINATOR,
     DOMAIN,
     CONF_CALENDARS,
     CONF_NEXT_DELIVERY,
@@ -38,10 +38,7 @@ async def async_setup_entry(
 
     calendars = entry.data[CONF_CALENDARS]
 
-    session = async_get_clientsession(hass)
-    coordinator = TMMCoordinator(hass, session, entry.data)
-
-    await coordinator.async_refresh()
+    coordinator = hass.data[DOMAIN][entry.entry_id][CONF_COORDINATOR]
 
     sensors = [TMMCalendarSensor(coordinator, entry.title)]
 

--- a/custom_components/themodernmilkman/const.py
+++ b/custom_components/themodernmilkman/const.py
@@ -20,6 +20,8 @@ CONF_NEXT_DELIVERY = "next_delivery"
 CONF_DELIVERYDATE = "deliveryDate"
 CONF_ITEMS = "items"
 CONF_UNKNOWN = "Unknown"
+CONF_COORDINATOR = "coordinator"
+SERVICE_REFRESH_DATA = "refresh_data"
 REQUEST_HEADER = {
     "Content-Type": "application/json",
 }

--- a/custom_components/themodernmilkman/const.py
+++ b/custom_components/themodernmilkman/const.py
@@ -18,6 +18,7 @@ CONF_BOTTLESSAVED = "bottlesSaved"
 CONF_WASTAGE = "wastage"
 CONF_NEXT_DELIVERY = "next_delivery"
 CONF_DELIVERYDATE = "deliveryDate"
+CONF_ITEMS = "items"
 CONF_UNKNOWN = "Unknown"
 REQUEST_HEADER = {
     "Content-Type": "application/json",

--- a/custom_components/themodernmilkman/sensor.py
+++ b/custom_components/themodernmilkman/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -20,6 +19,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import (
+    CONF_COORDINATOR,
     CONF_WASTAGE,
     CONF_BOTTLESSAVED,
     DOMAIN,
@@ -43,11 +43,7 @@ async def async_setup_entry(
         config.update(entry.options)
 
     if entry.data:
-        session = async_get_clientsession(hass)
-
-        coordinator = TMMCoordinator(hass, session, entry.data)
-
-        await coordinator.async_config_entry_first_refresh()
+        coordinator = hass.data[DOMAIN][entry.entry_id][CONF_COORDINATOR]
 
         wastage_sensor = TMMWastageSensor(coordinator, entry.title)
         next_delivery_sensor = TMMNextDeliverySensor(coordinator, entry.title)

--- a/custom_components/themodernmilkman/sensor.py
+++ b/custom_components/themodernmilkman/sensor.py
@@ -25,6 +25,7 @@ from .const import (
     DOMAIN,
     CONF_NEXT_DELIVERY,
     CONF_DELIVERYDATE,
+    CONF_ITEMS,
     CONF_UNKNOWN,
 )
 from .coordinator import TMMCoordinator
@@ -52,6 +53,14 @@ async def async_setup_entry(
         next_delivery_sensor = TMMNextDeliverySensor(coordinator, entry.title)
 
         sensors = [wastage_sensor, next_delivery_sensor]
+
+        next_delivery = coordinator.data.get(CONF_NEXT_DELIVERY)
+        if next_delivery and next_delivery != CONF_UNKNOWN:
+            items = next_delivery.get(CONF_ITEMS, [])
+            for index, item in enumerate(items[:5], start=1):
+                product_sensor = TMMProductSensor(coordinator, entry.title, index, item)
+                sensors.append(product_sensor)
+
         for sensor in sensors:
             hass.data[DOMAIN][sensor.unique_id] = sensor
 
@@ -157,6 +166,97 @@ class TMMNextDeliverySensor(CoordinatorEntity[DataUpdateCoordinator], SensorEnti
 
     @property
     def native_value(self) -> str | date | None:
+        """Native value."""
+        return self._state
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Define entity attributes."""
+        return self.attrs
+
+
+class TMMProductSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
+    """Define a sensor for a single product in the next delivery."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        name: str,
+        index: int,
+        item: dict,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{DOMAIN}")},
+            manufacturer="The Modern Milkman",
+            model="Milkround",
+            name=name,
+            configuration_url="https://github.com/jampez77/TheModernMilkman/",
+        )
+        self._index = index
+        self._item = item
+        sensor_id = f"{DOMAIN}_product_{index}".lower()
+        self._attr_unique_id = f"{DOMAIN}-{name}-product_{index}".lower()
+        self.entity_id = f"sensor.themodernmilkman_product_{index}"
+        self.entity_description = SensorEntityDescription(
+            key=f"themodernmilkman_product_{index}",
+            name=f"Product {index}",
+            icon="mdi:package-variant",
+        )
+        self._name = self.entity_description.name
+        self._sensor_id = sensor_id
+        self.attrs: dict[str, Any] = dict(item)
+        self._available = True
+        self._attr_force_update = True
+        self._attr_icon = self.entity_description.icon
+        self._state = item.get("productName")
+
+    def update_from_coordinator(self):
+        """Update sensor state and attributes from coordinator data."""
+        next_delivery = self.coordinator.data.get(CONF_NEXT_DELIVERY)
+        if next_delivery and next_delivery != CONF_UNKNOWN:
+            items = next_delivery.get(CONF_ITEMS, [])
+            if len(items) >= self._index:
+                self._item = items[self._index - 1]
+                self._state = self._item.get("productName")
+                self.attrs = dict(self._item)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.update_from_coordinator()
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Handle adding to Home Assistant."""
+        await super().async_added_to_hass()
+        await self.async_update()
+
+    @property
+    def name(self) -> str:
+        """Process name."""
+        return self._name
+
+    async def update_parcel(self) -> None:
+        """Safely update the name of the entity."""
+        await self.coordinator.async_request_refresh()
+
+        super()._handle_coordinator_update()
+
+    @property
+    def available(self) -> bool:
+        """Return if the entity is available."""
+        return self.coordinator.last_update_success and self._item is not None
+
+    @property
+    def icon(self) -> str:
+        """Return a representative icon of the product sensor."""
+        return self._attr_icon
+
+    @property
+    def native_value(self) -> str | None:
         """Native value."""
         return self._state
 

--- a/custom_components/themodernmilkman/services.yaml
+++ b/custom_components/themodernmilkman/services.yaml
@@ -1,0 +1,3 @@
+refresh_data:
+  name: Refresh data
+  description: Manually refresh data from The Modern Milkman API.

--- a/custom_components/themodernmilkman/strings.json
+++ b/custom_components/themodernmilkman/strings.json
@@ -17,5 +17,18 @@
       "abort": {
         "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
       }
+    },
+    "entity": {
+      "button": {
+        "themodernmilkman_refresh": {
+          "name": "Refresh"
+        }
+      }
+    },
+    "services": {
+      "refresh_data": {
+        "name": "Refresh data",
+        "description": "Manually refresh data from The Modern Milkman API."
+      }
     }
 }

--- a/custom_components/themodernmilkman/translations/en.json
+++ b/custom_components/themodernmilkman/translations/en.json
@@ -17,5 +17,18 @@
                 }
             }
         }
+    },
+    "entity": {
+        "button": {
+            "themodernmilkman_refresh": {
+                "name": "Refresh"
+            }
+        }
+    },
+    "services": {
+        "refresh_data": {
+            "name": "Refresh data",
+            "description": "Manually refresh data from The Modern Milkman API."
+        }
     }
 }


### PR DESCRIPTION
- Exposes first five products of the next delivery as product_1, product_2 etc
- Exposes an action and button to manually refresh the entities from the api